### PR TITLE
We need to escape some content to avoid malicious content:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ Changelog
   [gbastien]
 - Added `safe_utils.py` that will only include safe utils.
   [gbastien]
+- We need to escape some content to avoid malicious content:
+
+  - Rely on collective.eeafaceted.z3ctable to display the categorized content table, it manages esacaping content;
+  - Escape category title in vocabularies.
+
+  [gbastien]
 
 0.53 (2022-04-22)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
   [gbastien]
 - We need to escape some content to avoid malicious content:
 
-  - Rely on collective.eeafaceted.z3ctable to display the categorized content table, it manages esacaping content;
+  - Rely on collective.eeafaceted.z3ctable to display the categorized content table, it manages escaping content;
   - Escape category title in vocabularies.
 
   [gbastien]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,7 @@ parts +=
 develop = .
 
 auto-checkout =
+    collective.eeafaceted.z3ctable
     imio.helpers
 
 [instance]
@@ -99,6 +100,7 @@ imio_push = git@github.com:IMIO
 
 
 [sources]
+collective.eeafaceted.z3ctable = git ${remotes:collective}/collective.eeafaceted.z3ctable.git pushurl=${remotes:collective_push}/collective.eeafaceted.z3ctable.git
 imio.helpers = git ${remotes:imio}/imio.helpers.git pushurl=${remotes:imio_push}/imio.helpers.git
 
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -95,8 +95,17 @@ eggs = i18ndude
 
 
 [remotes]
+collective = https://github.com/collective
+collective_push = git@github.com:collective
+plone = https://github.com/plone
+plone_push = git@github.com:plone
+ftw = https://github.com/4teamwork
+ftw_push = git@github.com:4teamwork
 imio = https://github.com/IMIO
 imio_push = git@github.com:IMIO
+zopefoundation = https://github.com/zopefoundation
+zopefoundation_push = git@github.com:zopefoundation
+zopesvn = svn://svn.zope.org/repos/main/
 
 
 [sources]
@@ -115,3 +124,5 @@ future = 0.18.2
 natsort = 6.2.0
 # misc
 zc.lockfile = 2.0
+# required by collective.eeafaceted.z3ctable
+plone.formwidget.namedfile = 2.0.5

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'collective.documentviewer < 5',
+        'collective.documentviewer<5',
+        'collective.eeafaceted.z3ctable>2.17',
         'collective.fontawesome>=1.1',
-        'collective.js.tooltipster > 0.1',
+        'collective.js.tooltipster>0.1',
         'collective.z3cform.select2',
         'imio.helpers',
         'natsort',

--- a/src/collective/iconifiedcategory/browser/configure.zcml
+++ b/src/collective/iconifiedcategory/browser/configure.zcml
@@ -168,6 +168,7 @@
     template="templates/categorized-tab-view.pt"
     />
 
+  <!-- Columns -->
   <adapter
     name="title-column"
     for="zope.interface.Interface

--- a/src/collective/iconifiedcategory/browser/tabview.py
+++ b/src/collective/iconifiedcategory/browser/tabview.py
@@ -179,6 +179,8 @@ class TitleColumn(BaseColumn):
     header = _(u'Title')
     weight = 20
     attrName = 'title'
+    # we manage escape here manually
+    escape = False
 
     def renderCell(self, content):
         pattern = (
@@ -193,11 +195,11 @@ class TitleColumn(BaseColumn):
             target = '_blank'
         return pattern.format(
             link=url,
-            title=getattr(content, self.attrName).decode('utf-8'),
+            title=html.escape(getattr(content, self.attrName).decode('utf-8')),
             target=target,
             icon=content.icon_url,
-            category=safe_unicode(content.category_title),
-            description=safe_unicode(content.Description),
+            category=html.escape(safe_unicode(content.category_title)),
+            description=html.escape(safe_unicode(content.Description)),
         )
 
 

--- a/src/collective/iconifiedcategory/browser/tabview.py
+++ b/src/collective/iconifiedcategory/browser/tabview.py
@@ -7,6 +7,8 @@ Created by mpeeters
 :license: GPL, see LICENCE.txt for more details.
 """
 
+from collective.eeafaceted.z3ctable.browser.views import ExtendedCSSTable
+from collective.eeafaceted.z3ctable.columns import BaseColumn
 from collective.iconifiedcategory import _
 from collective.iconifiedcategory import utils
 from collective.iconifiedcategory.interfaces import ICategorizedConfidential
@@ -20,12 +22,12 @@ from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
-from z3c.table import column
-from z3c.table.table import Table
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
+
+import html
 
 
 class CategorizedTabView(BrowserView):
@@ -125,7 +127,7 @@ class CategorizedContent(object):
         return portal_url + '/' + suffix
 
 
-class CategorizedTable(Table, BrowserView):
+class CategorizedTable(ExtendedCSSTable, BrowserView):
     implements(ICategorizedTable)
 
     cssClasses = {'table': 'listing iconified-listing nosort'}
@@ -173,7 +175,7 @@ class CategorizedTable(Table, BrowserView):
         return super(CategorizedTable, self).render()
 
 
-class TitleColumn(column.GetAttrColumn):
+class TitleColumn(BaseColumn):
     header = _(u'Title')
     weight = 20
     attrName = 'title'
@@ -199,28 +201,29 @@ class TitleColumn(column.GetAttrColumn):
         )
 
 
-class CategoryColumn(column.GetAttrColumn):
+class CategoryColumn(BaseColumn):
     header = _(u'Category')
     weight = 30
     attrName = 'category_title'
+    escape = False
 
     def renderCell(self, content):
         category_title = safe_unicode(content.category_title)
         if content.subcategory_title:
             category_title = u"{0} / {1}".format(category_title,
                                                  safe_unicode(content.subcategory_title))
-        return category_title
+        return html.escape(category_title)
 
 
-class AuthorColumn(column.GetAttrColumn):
+class AuthorColumn(BaseColumn):
     header = _(u'Author')
     weight = 40
 
     def renderCell(self, content):
-        return content.Creator
+        return html.escape(content.Creator)
 
 
-class CreationDateColumn(column.GetAttrColumn):
+class CreationDateColumn(BaseColumn):
     header = _(u'Creation date')
     weight = 50
 
@@ -231,7 +234,7 @@ class CreationDateColumn(column.GetAttrColumn):
         )
 
 
-class LastModificationColumn(column.GetAttrColumn):
+class LastModificationColumn(BaseColumn):
     header = _(u'Last modification')
     weight = 60
 
@@ -244,7 +247,7 @@ class LastModificationColumn(column.GetAttrColumn):
         )
 
 
-class FilesizeColumn(column.GetAttrColumn):
+class FilesizeColumn(BaseColumn):
     header = _(u'Filesize')
     weight = 70
 
@@ -262,8 +265,9 @@ class FilesizeColumn(column.GetAttrColumn):
         return utils.render_filesize(content.filesize)
 
 
-class IconClickableColumn(column.GetAttrColumn):
+class IconClickableColumn(BaseColumn):
     action_view = ''
+    escape = False
 
     def _deactivated_is_useable(self):
         '''Is deactivated value a useable one?'''
@@ -381,9 +385,10 @@ class PublishableColumn(IconClickableColumn):
         )
 
 
-class ActionColumn(column.GetAttrColumn):
+class ActionColumn(BaseColumn):
     header = u''
     weight = 100
+    escape = False
 
     def renderCell(self, content):
         link = u'<a href="{href}"><img src="{src}" title="{title}" /></a>'

--- a/src/collective/iconifiedcategory/tests/test_tabview.py
+++ b/src/collective/iconifiedcategory/tests/test_tabview.py
@@ -22,7 +22,7 @@ class TestCategorizedTabView(BaseTestCase):
         self.assertTrue('File description' in result)
         self.assertTrue('<a href="http://nohost/plone/image" ' in result)
         self.assertTrue('Image description' in result)
-        self.assertTrue('<td>Category 1-1</td>' in result)
+        self.assertTrue('<td class="td_cell_category-column">Category 1-1</td>' in result)
 
         # 'to_print' and 'confidential' related columns are displayed by default
         self.assertTrue('<th>To be printed</th>' in result)

--- a/src/collective/iconifiedcategory/vocabularies.py
+++ b/src/collective/iconifiedcategory/vocabularies.py
@@ -11,6 +11,8 @@ from collective.iconifiedcategory import utils
 from imio.helpers.content import find
 from zope.schema.vocabulary import SimpleVocabulary
 
+import html
+
 
 class CategoryVocabulary(object):
 
@@ -41,7 +43,7 @@ class CategoryVocabulary(object):
                 category_id = category.UID()
             else:
                 category_id = utils.calculate_category_id(category)
-            category_title = category.Title()
+            category_title = html.escape(category.Title())
             if category.only_pdf:
                 category_title = category_title + ' [PDF!]'
             terms.append(SimpleVocabulary.createTerm(
@@ -56,7 +58,7 @@ class CategoryVocabulary(object):
                     subcategory_id = subcategory.UID()
                 else:
                     subcategory_id = utils.calculate_category_id(subcategory)
-                subcategory_title = subcategory.Title()
+                subcategory_title = html.escape(subcategory.Title())
                 if subcategory.only_pdf:
                     subcategory_title = subcategory_title + ' [PDF!]'
                 terms.append(SimpleVocabulary.createTerm(


### PR DESCRIPTION
- Rely on collective.eeafaceted.z3ctable to display the categorized content table, it manages esacaping content;
- Escape category title in vocabularies.
See #MOD-913