### PR TITLE
Avoid an error if category root folder does not exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.66 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Avoid an error if category root folder does not exist
+  [mpeeters]
 
 
 0.65 (2024-02-19)

--- a/src/collective/iconifiedcategory/indexes.py
+++ b/src/collective/iconifiedcategory/indexes.py
@@ -22,6 +22,6 @@ def content_category_uid(obj):
         return
     try:
         category_object = utils.get_category_object(obj, obj.content_category)
-    except KeyError:
+    except (KeyError, ValueError):
         return _marker
     return category_object.UID()


### PR DESCRIPTION
This fix the following traceback :

```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module Products.CMFPlone.CatalogTool, line 448, in manage_catalogRebuild
    Module plone.app.discussion.patches, line 52, in patchedClearFindAndRebuild
    Module OFS.FindSupport, line 239, in ZopeFindAndApply
    Module OFS.FindSupport, line 239, in ZopeFindAndApply
    Module OFS.FindSupport, line 239, in ZopeFindAndApply
    Module OFS.FindSupport, line 239, in ZopeFindAndApply
    Module OFS.FindSupport, line 239, in ZopeFindAndApply
    Module OFS.FindSupport, line 227, in ZopeFindAndApply
    Module plone.app.discussion.patches, line 31, in indexObject
    Module Products.CMFCore.CMFCatalogAware, line 68, in indexObject
    Module Products.CMFPlone.CatalogTool, line 331, in indexObject
    Module Products.CMFCore.CatalogTool, line 301, in reindexObject
    Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
    Module Products.ZCatalog.ZCatalog, line 506, in catalog_object
    Module Products.ZCatalog.Catalog, line 342, in catalogObject
    Module Products.ZCatalog.Catalog, line 293, in updateMetadata
    Module Products.ZCatalog.Catalog, line 414, in recordify
    Module plone.indexer.wrapper, line 65, in __getattr__
    Module plone.indexer.delegate, line 20, in __call__
    Module collective.iconifiedcategory.indexes, line 24, in content_category_uid
    Module collective.iconifiedcategory.utils, line 130, in get_category_object
    Module collective.iconifiedcategory.utils, line 74, in get_config_root

ValueError: Categories config cannot be found
```