### PR TITLE
Mod 1057:  Added error if frontend and backend data differ when setting values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Avoid an error if category root folder does not exist
   [mpeeters]
+- Added error if frontend and backend data differ when setting values.
+  [chris-adam]
 
 
 0.70 (2025-11-05)

--- a/src/collective/iconifiedcategory/browser/static/iconifiedcategory.js
+++ b/src/collective/iconifiedcategory/browser/static/iconifiedcategory.js
@@ -55,11 +55,11 @@ jQuery(function($) {
   //});
 
   $('a.iconified-action').click(function() {
-    var obj = $(this);
+    let obj = $(this);
     if (!obj.hasClass('editable')) {
       return false;
     }
-    var values = {'iconified-value': !obj.hasClass('active')};
+    let values = obj.data();
     $.getJSON(
       obj.attr('href'),
       values,
@@ -85,6 +85,17 @@ jQuery(function($) {
           }
         obj.attr('alt', data.msg);
         obj.attr('title', data.msg);
+
+        // Update all data-* attributes from the response
+        for (let key in data) {
+          if (key.startsWith('data-')) {
+            // Extract the data key name (remove 'data-' prefix)
+            let dataKey = key.substring(5);
+            // Update both the attribute and the data cache
+            obj.attr(key, data[key]);
+            obj.data(dataKey, data[key]);
+          }
+        }
       }
     );
     return false;

--- a/src/collective/iconifiedcategory/browser/tabview.py
+++ b/src/collective/iconifiedcategory/browser/tabview.py
@@ -322,13 +322,17 @@ class IconClickableColumn(BaseColumn):
             return '{0} editable'.format(base_css)
         return base_css
 
+    def render_data(self, content):
+        return u''
+
     def renderCell(self, content):
         link = (u'<a href="{0}" class="iconified-action{1}" alt="{2}" '
-                u'title="{2}"></a>')
+                u'title="{2}" {3}></a>')
         return link.format(
             self.get_url(content),
             self.css_class(content),
             self.alt(content),
+            self.render_data(content),
         )
 
 
@@ -346,6 +350,11 @@ class PrintColumn(IconClickableColumn):
             context=self.table.request,
         )
 
+    def render_data(self, content):
+        return u'data-to_print="{0}"'.format(
+            content.to_print and 'true' or 'false'
+        )
+
 
 class ConfidentialColumn(IconClickableColumn):
     header = _(u'Confidential')
@@ -359,6 +368,11 @@ class ConfidentialColumn(IconClickableColumn):
             utils.boolean_message(content, attr_name='confidential'),
             domain='collective.iconifiedcategory',
             context=self.table.request,
+        )
+
+    def render_data(self, content):
+        return u'data-confidential="{0}"'.format(
+            content.confidential and 'true' or 'false'
         )
 
 
@@ -383,6 +397,12 @@ class SignedColumn(IconClickableColumn):
     def is_deactivated(self, content):
         return not getattr(content, 'to_sign', True)
 
+    def render_data(self, content):
+        return u'data-to_sign="{0}" data-signed="{1}"'.format(
+            content.to_sign and 'true' or 'false',
+            content.signed and 'true' or 'false'
+        )
+
 
 class ApprovedColumn(IconClickableColumn):
     header = _(u'Approved')
@@ -405,6 +425,12 @@ class ApprovedColumn(IconClickableColumn):
     def is_deactivated(self, content):
         return not getattr(content, 'to_approve', True)
 
+    def render_data(self, content):
+        return u'data-to_approve="{0}" data-approved="{1}"'.format(
+            content.to_approve and 'true' or 'false',
+            content.approved and 'true' or 'false'
+        )
+
 
 class PublishableColumn(IconClickableColumn):
     header = _(u'Publishable')
@@ -418,6 +444,11 @@ class PublishableColumn(IconClickableColumn):
             utils.boolean_message(content, attr_name='publishable'),
             domain='collective.iconifiedcategory',
             context=self.table.request,
+        )
+
+    def render_data(self, content):
+        return u'data-publishable="{0}"'.format(
+            content.publishable and 'true' or 'false'
         )
 
 

--- a/src/collective/iconifiedcategory/locales/collective.iconifiedcategory.pot
+++ b/src/collective/iconifiedcategory/locales/collective.iconifiedcategory.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-10-08 08:22+0000\n"
+"POT-Creation-Date: 2025-12-01 15:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -334,6 +334,10 @@ msgstr ""
 
 #: ../utils.py:535
 msgid "You must select a PDF file!"
+msgstr ""
+
+#: ../browser/actionview.py:59
+msgid "Your action could not be performed because the content has been edited by another user."
 msgstr ""
 
 #: ../configure.zcml:32

--- a/src/collective/iconifiedcategory/locales/fr/LC_MESSAGES/collective.iconifiedcategory.po
+++ b/src/collective/iconifiedcategory/locales/fr/LC_MESSAGES/collective.iconifiedcategory.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-10-08 08:22+0000\n"
+"POT-Creation-Date: 2025-12-01 15:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -339,6 +339,10 @@ msgstr "oui et limiter l'accès au téléchargement"
 #: ../utils.py:535
 msgid "You must select a PDF file!"
 msgstr "La catégorie sélectionnée requiert l'utilisation d'un fichier au format PDF uniquement!"
+
+#: ../browser/actionview.py:59
+msgid "Your action could not be performed because the content has been edited by another user."
+msgstr "L'action n'a pas pu être effectuée car un autre utilisateur a modifié l'élément."
 
 #: ../configure.zcml:32
 msgid "collective.iconifiedcategory"

--- a/src/collective/iconifiedcategory/tests/test_actionview.py
+++ b/src/collective/iconifiedcategory/tests/test_actionview.py
@@ -25,8 +25,8 @@ class TestBaseView(BaseTestCase):
         self.assertEqual(result[u'msg'], u'No values to set')
 
         # only doable if user has Modify portal content on obj
-        view.attribute_mapping = {'title': 'action-value-title'}
-        self.portal.REQUEST.set('action-value-title', 'My new title')
+        view.attribute_mapping = {'approved': 'approved'}
+        self.portal.REQUEST.set('approved', 'false')
         obj.manage_permission(ModifyPortalContent, roles=[])
         result = reader.read(view())
         self.assertEqual(result[u'status'], 2)
@@ -34,11 +34,11 @@ class TestBaseView(BaseTestCase):
         obj.manage_permission(ModifyPortalContent, roles=['Manager'])
 
         # change title
-        self.assertEqual(obj.title, u'file.txt')
+        self.assertFalse(obj.approved)
         result = reader.read(view())
-        self.assertEqual(result[u'status'], -1)
+        self.assertEqual(result[u'status'], 1)
         self.assertEqual(result[u'msg'], u'Values have been set')
-        self.assertEqual(obj.title, 'My new title')
+        self.assertTrue(obj.approved)
 
     def test_get_current_values(self):
         obj = self.portal['file_txt']

--- a/src/collective/iconifiedcategory/tests/test_tabview.py
+++ b/src/collective/iconifiedcategory/tests/test_tabview.py
@@ -107,7 +107,8 @@ class TestCategorizedTabView(BaseTestCase):
             u'<a href="#" '
             u'class="iconified-action deactivated" '
             u'alt="Not convertible to a printable format" '
-            u'title="Not convertible to a printable format"></a>')
+            u'title="Not convertible to a printable format" '
+            u'data-to_print="false"></a>')
         self.assertIsNone(categorized_content.to_print)
         self.assertIsNone(obj.to_print)
 
@@ -130,7 +131,7 @@ class TestCategorizedTabView(BaseTestCase):
             u'<a href="http://nohost/plone/file_txt/@@iconified-print" '
             u'class="iconified-action editable" '
             u'alt="Should not be printed" '
-            u'title="Should not be printed"></a>')
+            u'title="Should not be printed" data-to_print="false"></a>')
 
         # set to_print to True
         obj.to_print = True
@@ -145,7 +146,7 @@ class TestCategorizedTabView(BaseTestCase):
             u'<a href="http://nohost/plone/file_txt/@@iconified-print" '
             u'class="iconified-action active editable" '
             u'alt="Must be printed" '
-            u'title="Must be printed"></a>')
+            u'title="Must be printed" data-to_print="true"></a>')
 
         # if element is not editable, the 'editable' CSS class is not there
         obj.manage_permission(ModifyPortalContent, roles=[])
@@ -153,4 +154,5 @@ class TestCategorizedTabView(BaseTestCase):
         self.assertEqual(column.renderCell(categorized_content),
                          u'<a href="http://nohost/plone/file_txt/@@iconified-print" '
                          u'class="iconified-action active" '
-                         u'alt="Must be printed" title="Must be printed"></a>')
+                         u'alt="Must be printed" title="Must be printed" '
+                         u'data-to_print="true"></a>')


### PR DESCRIPTION
Je suis moyennement convaincu de cette implémentation parce que ça signifie que le JS ne décide plus du tout de la valeur qu'on veut set, uniquement le backend. Et on ne peut plus set que de booléennes, sauf si on passe par `_get_next_values`. Et le attribute_mapping devient plus ou moins inutile