### PR TITLE
Display category infos on categorized item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.74 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Display category infos on categorized item.
+  [chris-adam]
 
 
 0.73 (2026-04-01)

--- a/src/collective/iconifiedcategory/behaviors/iconifiedcategorization.py
+++ b/src/collective/iconifiedcategory/behaviors/iconifiedcategorization.py
@@ -140,6 +140,7 @@ class IconifiedCategorization(object):
     def to_approve(self):
         return getattr(aq_base(self.context), 'to_approve', False)
 
+    @property
     def approved(self):
         return getattr(aq_base(self.context), 'approved', False)
 

--- a/src/collective/iconifiedcategory/browser/configure.zcml
+++ b/src/collective/iconifiedcategory/browser/configure.zcml
@@ -59,6 +59,16 @@
     permission="zope2.View"
     />
 
+  <browser:viewlet
+    name="iconifiedcategory.item.infos"
+    for="collective.iconifiedcategory.behaviors.iconifiedcategorization.IIconifiedCategorizationMarker"
+    manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+    layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
+    class=".viewlets.CategorizedItemInfoViewlet"
+    template="templates/categorized-item-info-viewlet.pt"
+    permission="zope2.View"
+    />
+
   <!-- Edit form views -->
   <browser:page
     name="edit"

--- a/src/collective/iconifiedcategory/browser/static/iconifiedcategory.css
+++ b/src/collective/iconifiedcategory/browser/static/iconifiedcategory.css
@@ -137,11 +137,11 @@ div.tooltipster-categorized-elements label {
 #content .iconified-listing td.iconified-approved a,
 #content .iconified-listing td.iconified-confidential a,
 #content .iconified-listing td.iconified-publishable a,
-div.tooltipster-categorized-elements span.iconified-print,
-div.tooltipster-categorized-elements span.iconified-confidential,
-div.tooltipster-categorized-elements span.iconified-publishable,
-div.tooltipster-categorized-elements span.iconified-signed,
-div.tooltipster-categorized-elements span.iconified-approved {
+div.categorized_elements_details span.iconified-print,
+div.categorized_elements_details span.iconified-confidential,
+div.categorized_elements_details span.iconified-publishable,
+div.categorized_elements_details span.iconified-signed,
+div.categorized_elements_details span.iconified-approved {
     font-family: 'Font Awesome 5 Free';
     font-size: 110%;
     cursor: help;
@@ -164,11 +164,11 @@ div.tooltipster-categorized-elements span.iconified-approved {
 #content .iconified-listing td.iconified-approved a,
 #content .iconified-listing td.iconified-confidential a.active,
 #content .iconified-listing td.iconified-publishable a,
-div.tooltipster-categorized-elements span.iconified-print,
-div.tooltipster-categorized-elements span.iconified-approved,
-div.tooltipster-categorized-elements span.iconified-confidential.active,
-div.tooltipster-categorized-elements span.iconified-publishable,
-div.tooltipster-categorized-elements span.iconified-signed {
+div.categorized_elements_details span.iconified-print,
+div.categorized_elements_details span.iconified-approved,
+div.categorized_elements_details span.iconified-confidential.active,
+div.categorized_elements_details span.iconified-publishable,
+div.categorized_elements_details span.iconified-signed {
     color: #EA0000;
 }
 
@@ -177,11 +177,11 @@ div.tooltipster-categorized-elements span.iconified-signed {
 #content .iconified-listing td.iconified-approved a.active,
 #content .iconified-listing td.iconified-confidential a,
 #content .iconified-listing td.iconified-publishable a.active,
-div.tooltipster-categorized-elements span.iconified-print.active,
-div.tooltipster-categorized-elements span.iconified-signed.active,
-div.tooltipster-categorized-elements span.iconified-approved.active,
-div.tooltipster-categorized-elements span.iconified-confidential,
-div.tooltipster-categorized-elements span.iconified-publishable.active {
+div.categorized_elements_details span.iconified-print.active,
+div.categorized_elements_details span.iconified-signed.active,
+div.categorized_elements_details span.iconified-approved.active,
+div.categorized_elements_details span.iconified-confidential,
+div.categorized_elements_details span.iconified-publishable.active {
     color: #75ad0a;
 }
 
@@ -206,11 +206,11 @@ div.tooltipster-categorized-elements span.iconified-publishable.active {
 #content .iconified-listing td.iconified-approved a.deactivated,
 #content .iconified-listing td.iconified-confidential a.deactivated,
 #content .iconified-listing td.iconified-publishable a.deactivated,
-div.tooltipster-categorized-elements span.iconified-print.deactivated,
-div.tooltipster-categorized-elements span.iconified-signed.deactivated,
-div.tooltipster-categorized-elements span.iconified-approved.deactivated,
-div.tooltipster-categorized-elements span.iconified-confidential.deactivated,
-div.tooltipster-categorized-elements span.iconified-publishable.deactivated {
+div.categorized_elements_details span.iconified-print.deactivated,
+div.categorized_elements_details span.iconified-signed.deactivated,
+div.categorized_elements_details span.iconified-approved.deactivated,
+div.categorized_elements_details span.iconified-confidential.deactivated,
+div.categorized_elements_details span.iconified-publishable.deactivated {
     color: silver;
 }
 
@@ -237,32 +237,32 @@ div.tooltipster-categorized-elements span.iconified-publishable.deactivated {
 }
 
 #content .iconified-listing td.iconified-print a:before,
-div.tooltipster-categorized-elements span.iconified-print:before {
+div.categorized_elements_details span.iconified-print:before {
     content: "\f02f";
 }
 
 #content .iconified-listing td.iconified-publishable a:before,
-div.tooltipster-categorized-elements span.iconified-publishable:before {
+div.categorized_elements_details span.iconified-publishable:before {
     content: "\f093";
 }
 
 #content .iconified-listing td.iconified-confidential a:before,
-div.tooltipster-categorized-elements span.iconified-confidential:before {
+div.categorized_elements_details span.iconified-confidential:before {
     content: "\f3c1";
 }
 
 #content .iconified-listing td.iconified-confidential a.active:before,
-div.tooltipster-categorized-elements span.iconified-confidential.active:before {
+div.categorized_elements_details span.iconified-confidential.active:before {
     content: "\f023";
 }
 
 #content .iconified-listing td.iconified-signed a:before,
-div.tooltipster-categorized-elements span.iconified-signed:before {
+div.categorized_elements_details span.iconified-signed:before {
     content: "\f044";
 }
 
 #content .iconified-listing td.iconified-approved a:before,
-div.tooltipster-categorized-elements span.iconified-approved:before {
+div.categorized_elements_details span.iconified-approved:before {
     content: "\f00c";
 }
 

--- a/src/collective/iconifiedcategory/browser/templates/categorized-childs-infos.pt
+++ b/src/collective/iconifiedcategory/browser/templates/categorized-childs-infos.pt
@@ -65,46 +65,7 @@
         </tal:filesize>
 
         <div class="categorized_elements_details" tal:condition="python: view.show_details(number_of_columns)">
-          <tal:show_to_print_icon condition="python: view.show(element, 'to_be_printed')">
-             <span class=""
-                   title=""
-                   i18n:attributes="title"
-                   tal:attributes="class python: view.get_css_classses_for('to_print', element);
-                                   title python: view.get_tag_title_for('to_print', element)">
-             </span>
-           </tal:show_to_print_icon>
-          <tal:show_confidential_icon condition="python: view.show(element, 'confidentiality')">
-             <span class=""
-                   title=""
-                   i18n:attributes="title"
-                   tal:attributes="class python: view.get_css_classses_for('confidential', element);
-                                   title python: view.get_tag_title_for('confidential', element)">
-             </span>
-           </tal:show_confidential_icon>
-          <tal:show_signed_icon condition="python: view.show(element, 'signed')">
-             <span class=""
-                   title=""
-                   i18n:attributes="title"
-                   tal:attributes="class python: view.get_css_classses_for('signed', element);
-                                   title python: view.get_tag_title_for('signed', element)">
-             </span>
-          </tal:show_signed_icon>
-          <tal:show_approved_icon condition="python: view.show(element, 'approved')">
-             <span class=""
-                   title=""
-                   i18n:attributes="title"
-                   tal:attributes="class python: view.get_css_classses_for('approved', element);
-                                   title python: view.get_tag_title_for('approved', element)">
-             </span>
-          </tal:show_approved_icon>
-          <tal:show_publishable_icon condition="python: view.show(element, 'publishable')">
-             <span class=""
-                   title=""
-                   i18n:attributes="title"
-                   tal:attributes="class python: view.get_css_classses_for('publishable', element);
-                                   title python: view.get_tag_title_for('publishable', element)">
-             </span>
-          </tal:show_publishable_icon>
+          <tal:icons replace="structure python: view.element_icons_html(element)" />
 
           <tal:show_download_icon condition="python: view.show_download(element)">
             <a tal:attributes="href string:${portal_url}/${element_url}">

--- a/src/collective/iconifiedcategory/browser/templates/categorized-element-icons.pt
+++ b/src/collective/iconifiedcategory/browser/templates/categorized-element-icons.pt
@@ -1,0 +1,43 @@
+<tal:icons define="element options/element"
+          i18n:domain="collective.iconifiedcategory">
+  <tal:show_to_print_icon condition="python: view.show(element, 'to_be_printed')">
+    <span class=""
+          title=""
+          i18n:attributes="title"
+          tal:attributes="class python: view.get_css_classses_for('to_print', element);
+                          title python: view.get_tag_title_for('to_print', element)">
+    </span>
+  </tal:show_to_print_icon>
+  <tal:show_confidential_icon condition="python: view.show(element, 'confidentiality')">
+    <span class=""
+          title=""
+          i18n:attributes="title"
+          tal:attributes="class python: view.get_css_classses_for('confidential', element);
+                          title python: view.get_tag_title_for('confidential', element)">
+    </span>
+  </tal:show_confidential_icon>
+  <tal:show_signed_icon condition="python: view.show(element, 'signed')">
+    <span class=""
+          title=""
+          i18n:attributes="title"
+          tal:attributes="class python: view.get_css_classses_for('signed', element);
+                          title python: view.get_tag_title_for('signed', element)">
+    </span>
+  </tal:show_signed_icon>
+  <tal:show_approved_icon condition="python: view.show(element, 'approved')">
+    <span class=""
+          title=""
+          i18n:attributes="title"
+          tal:attributes="class python: view.get_css_classses_for('approved', element);
+                          title python: view.get_tag_title_for('approved', element)">
+    </span>
+  </tal:show_approved_icon>
+  <tal:show_publishable_icon condition="python: view.show(element, 'publishable')">
+    <span class=""
+          title=""
+          i18n:attributes="title"
+          tal:attributes="class python: view.get_css_classses_for('publishable', element);
+                          title python: view.get_tag_title_for('publishable', element)">
+    </span>
+  </tal:show_publishable_icon>
+</tal:icons>

--- a/src/collective/iconifiedcategory/browser/templates/categorized-item-info-viewlet.pt
+++ b/src/collective/iconifiedcategory/browser/templates/categorized-item-info-viewlet.pt
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:tal="http://xml.zope.org/namespaces/tal"
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  i18n:domain="collective.iconifiedcategory" lang="en">
+
+  <div class="categorized_elements_details">
+    <tal:icons replace="structure python: view.element_icons_html(view.element)" />
+  </div>
+</html>

--- a/src/collective/iconifiedcategory/browser/viewlets.py
+++ b/src/collective/iconifiedcategory/browser/viewlets.py
@@ -7,8 +7,23 @@ Created by mpeeters
 :license: GPL, see LICENCE.txt for more details.
 """
 
+from collective.iconifiedcategory.browser.views import CategorizedElementsMixin
 from plone.app.layout.viewlets import common as base
 
 
 class CategorizedChildViewlet(base.ViewletBase):
     """ """
+
+
+class CategorizedItemInfoViewlet(CategorizedElementsMixin, base.ViewletBase):
+    """Viewlet showing the category status icons on a categorized item's view page."""
+
+    def __init__(self, context, request, view, manager=None):
+        super(CategorizedItemInfoViewlet, self).__init__(context, request, view, manager)
+        self.element = self.context.aq_parent.categorized_elements[self.context.UID()]
+
+    def show(self, element, attr_prefix):
+        return element['{0}_activated'.format(attr_prefix)]
+
+    def show_download(self, element):
+        return False

--- a/src/collective/iconifiedcategory/browser/views.py
+++ b/src/collective/iconifiedcategory/browser/views.py
@@ -22,10 +22,66 @@ from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import _checkPermission
 from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.component.interfaces import ComponentLookupError
 
 import json
+
+
+class CategorizedElementsMixin(object):
+    """Mixin providing shared icon rendering for categorized elements."""
+
+    _element_icons = ViewPageTemplateFile('templates/categorized-element-icons.pt')
+
+    def element_icons_html(self, element):
+        """Render the status icon spans for the given element."""
+        return self._element_icons(element=element)
+
+    def get_css_classses_for(self, functionnality, element):
+        """ """
+        css_classes = []
+        if functionnality == "to_print":
+            css_classes.append("iconified-print")
+            if element['to_print'] is None:
+                css_classes.append('deactivated')
+            elif element['to_print'] is True:
+                css_classes.append('active')
+        elif functionnality == "signed":
+            css_classes.append("iconified-signed")
+            if element['to_sign'] is False:
+                css_classes.append('deactivated')
+            elif element['signed'] is True:
+                css_classes.append('active')
+        elif functionnality == "approved":
+            css_classes.append("iconified-approved")
+            if element['to_approve'] is False:
+                css_classes.append('deactivated')
+            elif element['approved'] is True:
+                css_classes.append('active')
+        else:
+            # default behavior
+            css_classes.append("iconified-{0}".format(functionnality))
+            if element[functionnality] is True:
+                css_classes.append('active')
+        return " ".join(css_classes)
+
+    def get_tag_title_for(self, functionnality, element):
+        """ """
+        msg = ''
+        if functionnality == "to_print":
+            msg = print_message(to_print_value=element['to_print'])
+        elif functionnality == "signed":
+            msg = signed_message(to_sign_value=element['to_sign'],
+                                 signed_value=element['signed'])
+        elif functionnality == "approved":
+            msg = approved_message(to_approve_value=element['to_approve'],
+                                   approved_value=element['approved'])
+        else:
+            # default behavior, a boolean message
+            msg = boolean_message(attr_name=functionnality,
+                                  value=element[functionnality])
+        return msg
 
 
 class CategorizedChildView(BrowserView):
@@ -82,7 +138,7 @@ class ManageCategorizedChildView(BrowserView):
         return "{0}/@@iconifiedcategory".format(self.context.absolute_url())
 
 
-class CategorizedChildInfosView(BrowserView):
+class CategorizedChildInfosView(CategorizedElementsMixin, BrowserView):
     """ """
     def __init__(self, context, request):
         """ """
@@ -170,52 +226,6 @@ class CategorizedChildInfosView(BrowserView):
     def _show_detail(self, detail_type):
         """Made to be overrided."""
         return True
-
-    def get_css_classses_for(self, functionnality, element):
-        """ """
-        css_classes = []
-        if functionnality == "to_print":
-            css_classes.append("iconified-print")
-            if element['to_print'] is None:
-                css_classes.append('deactivated')
-            elif element['to_print'] is True:
-                css_classes.append('active')
-        elif functionnality == "signed":
-            css_classes.append("iconified-signed")
-            if element['to_sign'] is False:
-                css_classes.append('deactivated')
-            elif element['signed'] is True:
-                css_classes.append('active')
-        elif functionnality == "approved":
-            css_classes.append("iconified-approved")
-            if element['to_approve'] is False:
-                css_classes.append('deactivated')
-            elif element['approved'] is True:
-                css_classes.append('active')
-        else:
-            # default behavior
-            css_classes.append("iconified-{0}".format(functionnality))
-            if element[functionnality] is True:
-                css_classes.append('active')
-        return " ".join(css_classes)
-
-    def get_tag_title_for(self, functionnality, element):
-        """ """
-        msg = ''
-        if functionnality == "to_print":
-            msg = print_message(to_print_value=element['to_print'])
-        elif functionnality == "signed":
-            msg = signed_message(to_sign_value=element['to_sign'],
-                                 signed_value=element['signed'])
-        elif functionnality == "approved":
-            msg = approved_message(to_approve_value=element['to_approve'],
-                                   approved_value=element['approved'])
-        else:
-            # default behavior, a boolean message
-            msg = boolean_message(attr_name=functionnality,
-                                  value=element[functionnality])
-        return msg
-
 
 def check_can_view(obj, request):
     """ """


### PR DESCRIPTION
## Summary
Adds a viewlet (`iconifiedcategory.item.infos`, manager `IBelowContentTitle`) that renders the category
status icons (print / confidential / signed / approved / publishable) as **non-clickable** spans below a
categorized file's title, so the info is visible again on a file or annex view. It also opens
extensibility/robustness seams so downstream packages can specialize the icons without forking the template.

Key changes:
- Per-functionality dispatch in `browser/views.py` (`get_css_classses_for` / `get_tag_title_for` →
  `_css_for_<funct>` / `_title_for_<funct>`), no behavior change for existing callers.
- Crash-safe viewlet in `browser/viewlets.py` (guarded lazy `element`, `render()` returns `''` when absent).
- Template root fix (`tal:block` instead of a nested `<html>`).
- Data-driven icon list so subclasses can add/reorder without forking the template.
- Tests + `CHANGES.rst`.

## Pre-PR checks
- [x] CHANGES up to date
- [x] Tests exist for new code
- [x] Diff matches intent
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (N/A — browser-only, no profile changes)
- [x] Mergeable

## Commits
- c61f1fd Display category infos on categorized item
